### PR TITLE
Add Lightning Growth Feature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.16.7
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.1.0
 maven_group=dev.aaronfranke.size_helper_for_pehkui
 archives_base_name=size_helper_for_pehkui
 

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/LightningGrowMoment.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/LightningGrowMoment.java
@@ -1,31 +1,35 @@
 package dev.aaronfranke.size_helper_for_pehkui;
 
-import java.time.Instant;
-import java.time.Duration;
+import net.minecraft.world.World;
 
 public class LightningGrowMoment {
-	private final double growDurationSeconds;
+	private final World world;
+	private final int growDurationTicks;
+	private final long startingTick;
+	private final long endingTick;
 
-	private final Instant startedAt;
-	private final Instant doneAfter;
-
-	public LightningGrowMoment(double growDurationSeconds) {
-		this.growDurationSeconds = growDurationSeconds > 0 ? growDurationSeconds : 0.1;
-		startedAt = Instant.now();
-		doneAfter = startedAt.plusMillis((long) growDurationSeconds * 1000);
+	public LightningGrowMoment(double growDurationSeconds, World world) {
+		this.world = world;
+		this.growDurationTicks = (int) Math.max(2, Math.round(growDurationSeconds * 20)); // 20 ticks per second
+		this.startingTick = world.getTime();
+		this.endingTick = startingTick + growDurationTicks;
 	}
 
-	public boolean getIsDone() {
-		return Instant.now().isAfter(doneAfter);
+	public boolean isFinished() {
+		return isTickAtOrMoreThanEnd(world.getTime());
 	}
 
 	public double getAdjustedScaleMultiplier() {
-		final Instant now = Instant.now();
-		if (now.isAfter(doneAfter)) {
+		final long currentTick = world.getTime();
+		if (isTickAtOrMoreThanEnd(currentTick)) {
 			return 0.0;
 		}
-		final double elapsed = Duration.between(startedAt, now).toMillis() / 1000.0;
-		final double fraction = elapsed / growDurationSeconds;
+		final long elapsed = currentTick - startingTick;
+		final double fraction = (double) elapsed / (double) growDurationTicks;
 		return Math.max(0.0, 1.0 - fraction);
+	}
+
+	private boolean isTickAtOrMoreThanEnd(long tick) {
+		return tick >= endingTick;
 	}
 }

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/LightningGrowMoment.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/LightningGrowMoment.java
@@ -1,0 +1,31 @@
+package dev.aaronfranke.size_helper_for_pehkui;
+
+import java.time.Instant;
+import java.time.Duration;
+
+public class LightningGrowMoment {
+	private final double growDurationSeconds;
+
+	private final Instant startedAt;
+	private final Instant doneAfter;
+
+	public LightningGrowMoment(double growDurationSeconds) {
+		this.growDurationSeconds = growDurationSeconds > 0 ? growDurationSeconds : 0.1;
+		startedAt = Instant.now();
+		doneAfter = startedAt.plusMillis((long) growDurationSeconds * 1000);
+	}
+
+	public boolean getIsDone() {
+		return Instant.now().isAfter(doneAfter);
+	}
+
+	public double getAdjustedScaleMultiplier() {
+		final Instant now = Instant.now();
+		if (now.isAfter(doneAfter)) {
+			return 0.0;
+		}
+		final double elapsed = Duration.between(startedAt, now).toMillis() / 1000.0;
+		final double fraction = elapsed / growDurationSeconds;
+		return Math.max(0.0, 1.0 - fraction);
+	}
+}

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/LightningGrowMoment.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/LightningGrowMoment.java
@@ -10,7 +10,8 @@ public class LightningGrowMoment {
 
 	public LightningGrowMoment(double growDurationSeconds, World world) {
 		this.world = world;
-		this.growDurationTicks = (int) Math.max(2, Math.round(growDurationSeconds * 20)); // 20 ticks per second
+		// 20 ticks per second.
+		this.growDurationTicks = (int) Math.max(2, Math.round(growDurationSeconds * 20));
 		this.startingTick = world.getTime();
 		this.endingTick = startingTick + growDurationTicks;
 	}

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/PlayerStruckByLightningCallback.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/PlayerStruckByLightningCallback.java
@@ -1,0 +1,16 @@
+package dev.aaronfranke.size_helper_for_pehkui;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.LightningEntity;
+import net.minecraft.entity.player.PlayerEntity;
+
+public interface PlayerStruckByLightningCallback {
+	Event<PlayerStruckByLightningCallback> EVENT = EventFactory.createArrayBacked(PlayerStruckByLightningCallback.class, listeners -> (player, lightning) -> {
+		for (PlayerStruckByLightningCallback listener : listeners) {
+			listener.onPlayerStruckByLightning(player, lightning);
+		}
+	});
+
+	void onPlayerStruckByLightning(PlayerEntity player, LightningEntity lightning);
+}

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/ScaleSettings.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/ScaleSettings.java
@@ -162,7 +162,7 @@ public class ScaleSettings {
 			return;
 		}
 		// 900 seconds = 15 minutes. 15 minutes of growth from a lightning strike
-		lightningGrowMoments.putIfAbsent(lightningUuid, new LightningGrowMoment(30));
+		lightningGrowMoments.putIfAbsent(lightningUuid, new LightningGrowMoment(900));
 	}
 
 	public double getHeightMultiplier() {

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/ScaleSettings.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/ScaleSettings.java
@@ -1,5 +1,7 @@
 package dev.aaronfranke.size_helper_for_pehkui;
 
+import net.minecraft.world.World;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -157,12 +159,12 @@ public class ScaleSettings {
 		return utcDate.getMonth() == java.time.Month.APRIL && utcDate.getDayOfMonth() == 1;
 	}
 
-	public void onLightningStrike(UUID lightningUuid) {
+	public void onLightningStrike(UUID lightningUuid, World world) {
 		if (lightningGrowthMultiplier == 1) {
 			return;
 		}
 		// 900 seconds = 15 minutes. 15 minutes of growth from a lightning strike
-		lightningGrowMoments.putIfAbsent(lightningUuid, new LightningGrowMoment(900));
+		lightningGrowMoments.putIfAbsent(lightningUuid, new LightningGrowMoment(900, world));
 	}
 
 	public double getHeightMultiplier() {
@@ -172,7 +174,7 @@ public class ScaleSettings {
 
 		for (UUID uuid : lightningGrowMoments.keySet()) {
 			LightningGrowMoment moment = lightningGrowMoments.get(uuid);
-			if (moment.getIsDone()) {
+			if (moment.isFinished()) {
 				momentsToRemove.add(uuid);
 				continue;
 			}

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/ScaleSettings.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/ScaleSettings.java
@@ -35,7 +35,7 @@ public class ScaleSettings {
 	// The amount that 'height' will be multiplied with upon a lightning strike.
 	private double lightningGrowthMultiplier = 1.0;
 
-	// Map that stores lightning UUID -> LightningGrowMoments, so they can be added together
+	// Map that stores lightning UUID -> LightningGrowMoments, so they can be added together.
 	private final HashMap<UUID, LightningGrowMoment> lightningGrowMoments = new HashMap<>();
 
 	// Internal calculations.
@@ -163,7 +163,7 @@ public class ScaleSettings {
 		if (lightningGrowthMultiplier == 1) {
 			return;
 		}
-		// 900 seconds = 15 minutes. 15 minutes of growth from a lightning strike
+		// 900 seconds = 15 minutes. 15 minutes of growth from a lightning strike.
 		lightningGrowMoments.putIfAbsent(lightningUuid, new LightningGrowMoment(900, world));
 	}
 
@@ -173,7 +173,7 @@ public class ScaleSettings {
 		final ArrayList<UUID> momentsToRemove = new ArrayList<>();
 
 		for (UUID uuid : lightningGrowMoments.keySet()) {
-			LightningGrowMoment moment = lightningGrowMoments.get(uuid);
+			final LightningGrowMoment moment = lightningGrowMoments.get(uuid);
 			if (moment.isFinished()) {
 				momentsToRemove.add(uuid);
 				continue;
@@ -183,7 +183,7 @@ public class ScaleSettings {
 		momentsToRemove.forEach(lightningGrowMoments::remove);
 
 		if (totalMomentFraction > 0.0) {
-			// Blend between 1.0 and lightningGrowthMultiplier
+			// Blend between 1.0 and lightningGrowthMultiplier.
 			final double effectiveGrowth = 1.0 + ((lightningGrowthMultiplier - 1.0) * totalMomentFraction);
 			multiplier *= effectiveGrowth;
 		}

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/SizeHelperCommandinator.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/SizeHelperCommandinator.java
@@ -3,19 +3,28 @@ package dev.aaronfranke.size_helper_for_pehkui;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.entity.LightningEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Set;
+import java.util.*;
 
 public class SizeHelperCommandinator {
 	private ConfigFile configFile = new ConfigFile();
 	private final HashMap<String, ScaleSettings> allScaleSettings = new HashMap<>();
+
+	// Runs every time a player gets hit by lightning
+	public void onLightningStrike(PlayerEntity player, LightningEntity lightning) {
+		final String playerName = player.getEntityName();
+		final ScaleSettings settings = allScaleSettings.get(playerName);
+		if (settings == null) {
+			return;
+		}
+		settings.onLightningStrike(lightning.getUuid());
+	}
 
 	// Runs every frame as registered by SizeHelperForPehkui.
 	public void runSizeScalingCommands(MinecraftServer server, boolean disableUnused) {

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/SizeHelperCommandinator.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/SizeHelperCommandinator.java
@@ -23,7 +23,7 @@ public class SizeHelperCommandinator {
 		if (settings == null) {
 			return;
 		}
-		settings.onLightningStrike(lightning.getUuid());
+		settings.onLightningStrike(lightning.getUuid(), player.getWorld());
 	}
 
 	// Runs every frame as registered by SizeHelperForPehkui.

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/SizeHelperForPehkui.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/SizeHelperForPehkui.java
@@ -130,6 +130,8 @@ public class SizeHelperForPehkui implements ModInitializer {
 				commandinator.runSizeScalingCommands(server, false);
 			}
 		});
+		// Register a player lightning strike event
+		PlayerStruckByLightningCallback.EVENT.register(commandinator::onLightningStrike);
 		LOGGER.info("Loaded Size Helper for Pehkui by aaronfranke!");
 	}
 

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/mixin/EntityMixin.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/mixin/EntityMixin.java
@@ -1,0 +1,21 @@
+package dev.aaronfranke.size_helper_for_pehkui.mixin;
+
+import dev.aaronfranke.size_helper_for_pehkui.PlayerStruckByLightningCallback;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LightningEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Entity.class)
+public class EntityMixin {
+	@Inject(method = "onStruckByLightning", at = @At("HEAD"))
+	private void onStruckByLightningMixin(ServerWorld world, LightningEntity lightning, CallbackInfo ci) {
+		if ((Object) this instanceof PlayerEntity player) {
+			PlayerStruckByLightningCallback.EVENT.invoker().onPlayerStruckByLightning(player, lightning);
+		}
+	}
+}

--- a/src/main/java/dev/aaronfranke/size_helper_for_pehkui/suggestion_providers/ScaleSettingSuggestionProvider.java
+++ b/src/main/java/dev/aaronfranke/size_helper_for_pehkui/suggestion_providers/ScaleSettingSuggestionProvider.java
@@ -25,6 +25,7 @@ public class ScaleSettingSuggestionProvider implements SuggestionProvider<Server
 		"hitbox_width",
 		"motion",
 		"third_person_distance",
+		"lightning_growth_multiplier",
 	};
 
 	@Override

--- a/src/main/resources/size_helper_for_pehkui.mixins.json
+++ b/src/main/resources/size_helper_for_pehkui.mixins.json
@@ -4,7 +4,7 @@
 	"compatibilityLevel": "JAVA_17",
 	"mixins": [
 		"EntityMixin"
-    ],
+	],
 	"injectors": {
 		"defaultRequire": 1
 	}

--- a/src/main/resources/size_helper_for_pehkui.mixins.json
+++ b/src/main/resources/size_helper_for_pehkui.mixins.json
@@ -2,7 +2,9 @@
 	"required": true,
 	"package": "dev.aaronfranke.size_helper_for_pehkui.mixin",
 	"compatibilityLevel": "JAVA_17",
-	"mixins": [],
+	"mixins": [
+		"EntityMixin"
+    ],
 	"injectors": {
 		"defaultRequire": 1
 	}


### PR DESCRIPTION
This will add a new feature that allows players to grow (or shrink) when struck with lightning.
- Adds new config setting: 'lightning_growth_multiplier'. Positive double. This is the multiplier that multiplies with the set height multiplier. For instances, a player with 'height_meters' as 2.0, and 'lightning_growth_multiplier' as 2.0, will grow to 4.0 meters tall when struck
- Lasts for 15 minutes: When struck, the player will grow to their lightning growth scale, then slowly approach to their default scale over the course of 15 minutes. This is not configurable, but can easily be made so in the future

Changes:
- SizeSettings will now make sure the resulting player size is within the bounds. This is an improvement than just checking when a size config command is ran